### PR TITLE
Added Requirements section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ Or download from release page
 
 * [Windows](https://github.com/klaushauschild1984/impex.js/releases/download/v1.0.0/format-impex.exe)
 * [Linux](https://github.com/klaushauschild1984/impex.js/releases/download/v1.0.0/format-impex)
+
+### Requirements
+* Node.js 12+
+* For building binaries: Node.js version should be supported by `nexe`, see https://github.com/nexe/nexe/releases


### PR DESCRIPTION
I've checked what was the problem with windows binary - `.matchAll` string method is supported only from Node.js 12.0.
After upding local Node.js versions (God bless nvm) I found that some of Node.js are not supported by `nexe`.
On Windows Node.js version 12.18.2 binary works as expected.